### PR TITLE
for-15-05: luci-mod-admin-full: update IPv4/IPv6 list views

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_overview.htm
@@ -139,32 +139,22 @@
 
 						if (ifc.ipaddrs && ifc.ipaddrs.length)
 						{
-							html += '<strong><%:IPv4%>: </strong>';
-
 							for (var i = 0; i < ifc.ipaddrs.length; i++)
 								html += String.format(
-									'%s%s/%d',
-									i ? ', ' : '',
+									'<strong><%:IPv4%>:</strong> %s/%d<br />',
 									ifc.ipaddrs[i].addr,
 									ifc.ipaddrs[i].prefix
 								);
-
-							html += '<br />';
 						}
 
 						if (ifc.ip6addrs && ifc.ip6addrs.length)
 						{
-							html += '<strong><%:IPv6%>: </strong>';
-
 							for (var i = 0; i < ifc.ip6addrs.length; i++)
 								html += String.format(
-									'%s%s/%d',
-									i ? ', ' : '',
-									ifc.ip6addrs[i].addr.toUpperCase(),
+									'<strong><%:IPv6%>:</strong> %s/%d<br />',
+									ifc.ip6addrs[i].addr,
 									ifc.ip6addrs[i].prefix
 								);
-
-							html += '<br />';
 						}
 
 						d.innerHTML = html;


### PR DESCRIPTION
Clarify address presentation on the Network/Interfaces page
by backporting f8d0ba00b2ff27dc9e2f10712bc343ae655fbdf9 :
  For better view of 'Interface Overview' IPv4/IPv6 addresses for
  interfaces should be displayed as lists, but not as comma separated
  strings.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
