### PR TITLE
luci-mod-admin-full: interface status page / clarify address display

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_status.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/iface_status.htm
@@ -39,32 +39,22 @@
 
 					if (ifc.ipaddrs && ifc.ipaddrs.length)
 					{
-						html += '<strong><%:IPv4%>: </strong>';
-
 						for (var i = 0; i < ifc.ipaddrs.length; i++)
 							html += String.format(
-								'%s%s/%d',
-								i ? ', ' : '',
+								'<strong><%:IPv4%>:</strong> %s/%d<br />',
 								ifc.ipaddrs[i].addr,
 								ifc.ipaddrs[i].prefix
 							);
-
-						html += '<br />';
 					}
 
 					if (ifc.ip6addrs && ifc.ip6addrs.length)
 					{
-						html += '<strong><%:IPv6%>: </strong>';
-
 						for (var i = 0; i < ifc.ip6addrs.length; i++)
 							html += String.format(
-								'%s%s/%d',
-								i ? ', ' : '',
-								ifc.ip6addrs[i].addr.toUpperCase(),
+								'<strong><%:IPv6%>:</strong> %s/%d<br />',
+								ifc.ip6addrs[i].addr,
 								ifc.ip6addrs[i].prefix
 							);
-
-						html += '<br />';
 					}
 
 					d.innerHTML = html;


### PR DESCRIPTION
Backport commit e42e5f58651983b9971c2facb08354cc2273dbef
  Copy the changes made by f8d0ba0
  also to the interface details pages in order to clarify display of
  multiple addresses.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
