### PR TITLE
luci-proto-ipv6: allow hostnames for dslite peer addresses (#621)

### DIFF
--- a/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_dslite.lua
@@ -14,7 +14,7 @@ peeraddr = section:taboption("general", Value, "peeraddr",
 	translate("DS-Lite AFTR address"))
 
 peeraddr.rmempty  = false
-peeraddr.datatype = "ip6addr"
+peeraddr.datatype = "or(hostname,ip6addr)"
 
 ip6addr = section:taboption("general", Value, "ip6addr",
 	translate("Local IPv6 address"),


### PR DESCRIPTION
Signed-off-by: Jo-Philipp Wich jow@openwrt.org
