### PR TITLE
luci-base: properly handle ubus connections for non-root (#570, #571)

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -402,9 +402,6 @@ function dispatch(request)
 	end
 
 	if track.setuser then
-		-- trigger ubus connection before dropping root privs
-		util.ubus()
-
 		sys.process.setuser(track.setuser)
 	end
 

--- a/modules/luci-base/root/usr/share/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/acl.d/luci-base.json
@@ -1,0 +1,8 @@
+{
+	"user": "nobody",
+	"access": {
+		"system": {
+			"methods": [ "board", "info" ]
+		}
+	}
+}


### PR DESCRIPTION
Instead of relying on the connect-before-setuid hack, ship a proper
acl definition file whitelisting the procedures that LuCI requires
on its non-root pages.

Signed-off-by: Jo-Philipp Wich jow@openwrt.org
