### PR TITLE
luci-app-radvd: mark BROKEN as radvd is still in oldpackages

### DIFF
--- a/applications/luci-app-radvd/Makefile
+++ b/applications/luci-app-radvd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2008-2016 The LuCI Team <luci@lists.subsignal.org>
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Support for Radvd
-LUCI_DEPENDS:=+radvd
+LUCI_DEPENDS:=+radvd @BROKEN
 
 include ../../luci.mk
 


### PR DESCRIPTION
Mark luci-app-radvd BROKEN as it has dependency to radvd,
which is still in oldpackages repo.

This commit fixes #553

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
