### PR TITLE
luci-mod-admin-full: Fix dhcpv6 ra_management option stateless value

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/ifaces.lua
@@ -492,8 +492,9 @@ if has_dnsmasq and net:proto() == "static" then
 		o:value("relay", translate("relay mode"))
 		o:value("hybrid", translate("hybrid mode"))
 
-		o = s:taboption("ipv6", ListValue, "ra_management", translate("DHCPv6-Mode"))
-		o:value("", translate("stateless"))
+		o = s:taboption("ipv6", ListValue, "ra_management", translate("DHCPv6-Mode"),
+			translate("Default is stateless + stateful"))
+		o:value("0", translate("stateless"))
 		o:value("1", translate("stateless + stateful"))
 		o:value("2", translate("stateful-only"))
 		o:depends("dhcpv6", "server")


### PR DESCRIPTION
Fix dhcpv6 ra_management option's handling of "stateless" value.
Default value for the option is 1, so trying to store ""
instead of "0" for stateless is not working.

This fixes #676

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
