### PR TITLE
luci-base: fix bug in util.lua in 'shellsqescape'

### DIFF
--- a/modules/luci-base/luasrc/util.lua
+++ b/modules/luci-base/luasrc/util.lua
@@ -157,7 +157,7 @@ end
 -- command line parameter).
 function shellsqescape(value)
    local res
-   res, _ = string.gsub(res, "'", "'\\''")
+   res, _ = string.gsub(value, "'", "'\\''")
    return res
 end
 


### PR DESCRIPTION
Fix a bug introduced by #561

Function 'shellsqescape' calls 'gsub' with the empty result string 'res'
instead of the actual parameter 'value'. This leads into error:
.../util.lua:160: bad argument #1 to 'gsub' (string expected, got nil)

Fix error by passing the correct parameter to the function.

After the fix, the unmount button introduced by #561 finally works.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
