### PR TITLE
luci-app-transmission: remove dependency on transmission-daemon

### DIFF
--- a/applications/luci-app-transmission/Makefile
+++ b/applications/luci-app-transmission/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2008-2016 The LuCI Team <luci@lists.subsignal.org>
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Support for Transmission
-LUCI_DEPENDS:=+transmission-daemon
+LUCI_DEPENDS:=
 
 include ../../luci.mk
 


### PR DESCRIPTION
transmission-daemon was split to -openssl and -polarssl variants,
so the old dependency needs to be removed.

luci-app-transmission will not install the transmission package
from now on. Instead the required transmission-daemon variant
needs to be installed separately.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
