### PR TITLE
luci-base: read odhcpd leasefile location via uci

### DIFF
--- a/modules/luci-base/luasrc/tools/status.lua
+++ b/modules/luci-base/luasrc/tools/status.lua
@@ -48,7 +48,15 @@ local function dhcp_leases_common(family)
 		fd:close()
 	end
 
-	local fd = io.open("/tmp/hosts/odhcpd", "r")
+	local lease6file = "/tmp/hosts/odhcpd"
+	uci:foreach("dhcp", "odhcpd",
+		function(t)
+			if t.leasefile and nfs.access(t.leasefile) then
+				lease6file = t.leasefile
+				return false
+			end
+		end)
+	local fd = io.open(lease6file, "r")
 	if fd then
 		while true do
 			local ln = fd:read("*l")


### PR DESCRIPTION
Check the location of the odhcpd leasefile from /etc/config/dhcp
via uci. Fallback to the default location.

This fixes #702

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
(cherry picked from commit 51a7f96877d8c5bf70217073ed8aa7ab6a196d20)
